### PR TITLE
Change split character for coordinates

### DIFF
--- a/src/layer/KML.js
+++ b/src/layer/KML.js
@@ -158,7 +158,7 @@ L.Util.extend(L.KML, {
 	parseCoords: function(xml) {
 		var el = xml.getElementsByTagName('coordinates');
 		var coords = [];
-		var text = el[0].childNodes[0].nodeValue.split(' ');
+		var text = el[0].childNodes[0].nodeValue.split(/[\s\n]+/);
 		for (var i = 0; i < text.length; i++) {
 			var ll = text[i].split(',');
 			if (ll.length < 2) continue;


### PR DESCRIPTION
Found a file with coordinates split by line, not by spaces.
