### PR TITLE
Fix calls to parseFolder to stop processing folders multiple times; call...

### DIFF
--- a/src/layer/KML.js
+++ b/src/layer/KML.js
@@ -19,7 +19,12 @@ L.KML = L.FeatureGroup.extend({
 		if (req.status != 200) return;
 		var layers = L.KML.parseKML(req.responseXML);
 		for (var i = 0; i < layers.length; i++)
+		{
+			this.fire('addlayer', {
+				layer: layers[i]
+			});
 			this.addLayer(layers[i]);
+		}
 		this.latLngs = L.KML.getLatLngs(req.responseXML);
 	},
 

--- a/src/layer/KML.js
+++ b/src/layer/KML.js
@@ -5,12 +5,12 @@ L.KML = L.FeatureGroup.extend({
 		L.Util.setOptions(this, options);
 		this._kml = kml;
 		this._layers = {};
-		
+
 		if (kml) {
 			this.addKML(kml);
 		}
 	},
-	
+
 	addKML: function(kml) {
 		var req = new window.XMLHttpRequest();
 		req.open('GET', kml, false);
@@ -165,7 +165,12 @@ L.Util.extend(L.KML, {
 	parseCoords: function(xml) {
 		var el = xml.getElementsByTagName('coordinates');
 		var coords = [];
-		var text = el[0].childNodes[0].nodeValue.split(/[\s\n]+/);
+		// text might span many childnodes if more than 4096 chars
+		var text = "";
+		for (var i = 0; i < el[0].childNodes.length; i++) {
+			text = text + el[0].childNodes[i].nodeValue;
+		}
+		text = text.split(/[\s\n]+/);
 		for (var i = 0; i < text.length; i++) {
 			var ll = text[i].split(',');
 			if (ll.length < 2) continue;

--- a/src/layer/KML.js
+++ b/src/layer/KML.js
@@ -29,7 +29,8 @@ L.Util.extend(L.KML, {
 		var el = xml.getElementsByTagName("Folder");
 		var layers = [];
 		for (var i = 0; i < el.length; i++) {
-			var l = this.parseFolder(xml, style);
+			if (!this._check_folder(el[i])) continue;
+			var l = this.parseFolder(el[i], style);
 			if (l) layers.push(l);
 		}
 		el = xml.getElementsByTagName('Placemark');
@@ -41,11 +42,13 @@ L.Util.extend(L.KML, {
 		return layers;
 	},
 
+	// Return false if e's first parent Folder is not [folder]
+	// - returns true if no parent Folders
 	_check_folder: function(e, folder) {
 		e = e.parentElement;
-		while (e && e.tagName != "Folder" && e != folder)
+		while (e && e.tagName != "Folder")
 			e = e.parentElement;
-		return e || e == folder;
+		return !e || e == folder;
 	},
 
 	parseStyle: function(xml) {


### PR DESCRIPTION
...ing _check_folder more often to ensure the functions are not looking too deep (process one level at a time).

I'm not certain why folders are processed really, the Placemarks could just be iterated through; I suppose there are names associated with the folders that could be used somewhere. Didn't want to completely rewrite, just tweak so it wasn't drawing routes multiple times.
